### PR TITLE
recovery.fstab: properly mount system as root

### DIFF
--- a/recovery.fstab
+++ b/recovery.fstab
@@ -6,7 +6,7 @@
 /boot          emmc    /dev/block/bootdevice/by-name/boot
 /cache         ext4    /dev/block/bootdevice/by-name/cache
 /recovery      emmc    /dev/block/bootdevice/by-name/recovery                    flags=backup=1
-/system        ext4    /dev/block/bootdevice/by-name/system
+/system_root   ext4    /dev/block/bootdevice/by-name/system                      flags=display="system"
 /vendor        ext4    /dev/block/bootdevice/by-name/vendor                      flags=display="vendor";backup=1;wipeingui
 
 /system_image  emmc    /dev/block/bootdevice/by-name/system

--- a/recovery/root/init.recovery.qcom.rc
+++ b/recovery/root/init.recovery.qcom.rc
@@ -28,6 +28,7 @@
 on fs
     wait /dev/block/platform/soc/${ro.boot.bootdevice}
     symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
+    export ANDROID_ROOT /system_root
     chmod 0660 /dev/qseecom
     chown system drmrpc /dev/qseecom
     chmod 0664 /dev/ion


### PR DESCRIPTION
as per AOSP standard behavior, the system partition of a system_as_root
device should be mounted at `/system_root` instead of `/system`.